### PR TITLE
URL navigation

### DIFF
--- a/app.R
+++ b/app.R
@@ -119,16 +119,20 @@ ui <- page_navbar(
 server <- function(input, output, session){
   
   # navigation & URL manipulation
+  # change the URL when the user moves tab
   observeEvent(input$batR_navigation, {
     # https://stackoverflow.com/questions/70080803/uri-routing-for-shinydashboard-using-shiny-router/70093686#70093686
     client_data <- reactiveValuesToList(session$clientData)
     newURL <- with(client_data, paste0(url_protocol, "//", url_hostname, ":", url_port, url_pathname, "#", input$batR_navigation))
-    updateQueryString(newURL, mode = "replace", session)
-    
-    # other resources:
-    # https://stackoverflow.com/questions/71541259/uri-routing-with-shiny-router-and-navbarpage-in-a-r-shiny-app
-    # https://stackoverflow.com/questions/74852297/uri-routing-with-shiny-router-and-navbarpage-using-secondary-navigation
+    updateQueryString(newURL, mode = "push", session)
   })
+  
+  # change the tab to match the URL
+  
+  
+  # other resources:
+  # https://stackoverflow.com/questions/71541259/uri-routing-with-shiny-router-and-navbarpage-in-a-r-shiny-app
+  # https://stackoverflow.com/questions/74852297/uri-routing-with-shiny-router-and-navbarpage-using-secondary-navigation
   
   # connect to duckdb ----
   con <- DBI::dbConnect(duckdb(), "data/t20_batting_data.duckdb")

--- a/app.R
+++ b/app.R
@@ -84,6 +84,8 @@ source("modules/stats_breakdown.R")
 ui <- page_navbar(
   title = "batR",
   
+  id = "batR_navigation",
+  
   selected = "batR",
   
   useShinyjs(),
@@ -115,6 +117,18 @@ ui <- page_navbar(
 
 #---- server ----
 server <- function(input, output, session){
+  
+  # navigation & URL manipulation
+  observeEvent(input$batR_navigation, {
+    # https://stackoverflow.com/questions/70080803/uri-routing-for-shinydashboard-using-shiny-router/70093686#70093686
+    client_data <- reactiveValuesToList(session$clientData)
+    newURL <- with(client_data, paste0(url_protocol, "//", url_hostname, ":", url_port, url_pathname, "#", input$batR_navigation))
+    updateQueryString(newURL, mode = "replace", session)
+    
+    # other resources:
+    # https://stackoverflow.com/questions/71541259/uri-routing-with-shiny-router-and-navbarpage-in-a-r-shiny-app
+    # https://stackoverflow.com/questions/74852297/uri-routing-with-shiny-router-and-navbarpage-using-secondary-navigation
+  })
   
   # connect to duckdb ----
   con <- DBI::dbConnect(duckdb(), "data/t20_batting_data.duckdb")

--- a/app.R
+++ b/app.R
@@ -119,20 +119,21 @@ ui <- page_navbar(
 server <- function(input, output, session){
   
   # navigation & URL manipulation
-  # change the URL when the user moves tab
+  # change URL when the user moves tab
   observeEvent(input$batR_navigation, {
-    # https://stackoverflow.com/questions/70080803/uri-routing-for-shinydashboard-using-shiny-router/70093686#70093686
     client_data <- reactiveValuesToList(session$clientData)
     newURL <- with(client_data, paste0(url_protocol, "//", url_hostname, ":", url_port, url_pathname, "#", input$batR_navigation))
-    updateQueryString(newURL, mode = "push", session)
+    updateQueryString(newURL, mode = "replace", session)
   })
   
   # change the tab to match the URL
+  observe({
+    current_tab <- URLdecode(sub("#", "", session$clientData$url_hash))
+    if(!is.null(current_tab)){
+      nav_select("batR_nvaigation", current_tab)
+    }
+  })
   
-  
-  # other resources:
-  # https://stackoverflow.com/questions/71541259/uri-routing-with-shiny-router-and-navbarpage-in-a-r-shiny-app
-  # https://stackoverflow.com/questions/74852297/uri-routing-with-shiny-router-and-navbarpage-using-secondary-navigation
   
   # connect to duckdb ----
   con <- DBI::dbConnect(duckdb(), "data/t20_batting_data.duckdb")


### PR DESCRIPTION
Added observers to manipulate the URL according to the tab selected and change tabs according to the URL. Didn't use shiny.router because it is limited in compatibility and this is a more generalisable solution to port to other apps